### PR TITLE
changes transform detection - now, if browser supports 'standart' transf...

### DIFF
--- a/js/utils/poly.js
+++ b/js/utils/poly.js
@@ -7,7 +7,7 @@
   (function() {
 
     // transform
-    var i, keys = ['webkitTransform', 'transform', '-webkit-transform', 'webkit-transform',
+    var i, keys = ['transform', 'webkitTransform', '-webkit-transform', 'webkit-transform',
                    '-moz-transform', 'moz-transform', 'MozTransform', 'mozTransform', 'msTransform'];
 
     for (i = 0; i < keys.length; i++) {


### PR DESCRIPTION
...orm style,

it will be used instead of vendor-specific one, i.e. 'transform' instead of 'webkitTransform'.
